### PR TITLE
Include file as string

### DIFF
--- a/t/include.js
+++ b/t/include.js
@@ -5,6 +5,7 @@ var include = require('../index'),
 var tests = [
   'location.json',
   'literal.json',
+  'string.json',
   'map.json',
   'flatten.json',
   'jmespath.json',
@@ -29,8 +30,8 @@ tests.forEach(function(file) {
             typeof(test.output) === 'function' ? assert.ok(test.output(json) === true) : assert.deepEqual(json, test.output);
             done();
           }).catch(test.catch ? function(err) {
-              assert.ok(test.catch(err) === true);
-              done();
+            assert.ok(test.catch(err) === true);
+            done();
           } : done);
         });
       });

--- a/t/tests/errors.js
+++ b/t/tests/errors.js
@@ -20,5 +20,17 @@ module.exports = {
       "Fn::Include": "includes/broken/commawithcomment.json"
     },
     output: {"foo":"bar", "/* coment": "value */"}
+  }, {
+    name: "ref in string",
+    template: {
+      "Fn::Include": "includes/literal.txt",
+      context: {
+        "Ref": "AWS::StackId"
+      }
+    },
+    output: function() { return true; },
+    catch: function(err) {
+      return err instanceof Error && err.message === 'refs not allowed in strings';
+    }
   }]
 }

--- a/t/tests/string.json
+++ b/t/tests/string.json
@@ -1,0 +1,44 @@
+{
+  "string": [{
+    "name": "no context",
+    "template": {
+      "Fn::Include": {
+        "location": "includes/literal.txt",
+        "type": "string"
+      }
+    },
+    "output": "#!/bin/bash\n\ncfn-signal {{stack}} foobar"
+  }, {
+    "name": "empty context",
+    "template": {
+      "Fn::Include": {
+        "location": "includes/literal.txt",
+        "type": "string",
+        "context": {}
+      }
+    },
+    "output": "#!/bin/bash\n\ncfn-signal  foobar"
+  }, {
+    "name": "with context",
+    "template": {
+      "Fn::Include": {
+        "location": "includes/literal.txt",
+        "type": "string",
+        "context": {
+          "stack": "StackID"
+        }
+      }
+    },
+    "output": "#!/bin/bash\n\ncfn-signal StackID foobar"
+  }, {
+    "name": "single line with Fn::Sub",
+    "template": {
+      "Fn::Sub": {
+        "Fn::Include": "includes/literalsub.txt"
+      }
+    },
+    "output": {
+      "Fn::Sub": "cfn-signal ${AWS::StackId} foobar"
+    }
+  }]
+}


### PR DESCRIPTION
Includes files as a single string to work around issues with Fn::Join within Fn:Sub. (See issue #25)

Works pretty well, the only drawback is you can't use !Refs within the include context.
