### PR TITLE
cli --context

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Options:
 * `--bucket`         bucket name required for templates larger than 50k
 * `--prefix`         prefix for templates uploaded to the bucket ['cfn-include']
 * `--version`        print version and exit
+* `--context`        template full path. only utilized for stdin when the template is piped to this script
+  example:          `cat examples/base.template | ./bin/cli.js --context examples/base.template`
 
 `cfn-include` also accepts a template passed from stdin
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -41,6 +41,11 @@ var _ = require('lodash'),
       bucket: {
         desc: 'bucket name required for templates larger than 50k',
       },
+      context: {
+        desc: 'template full path. only utilized for stdin when the template is piped to this script',
+        required: false,
+        string: true,
+      },
       prefix: {
         desc: 'prefix for templates uploaded to the bucket',
         default: 'cfn-include',
@@ -79,9 +84,13 @@ if (opts.path) {
       console.error('empty template received from stdin');
       process.exit(1);
     }
+
+    const location = opts.context ? path.resolve(opts.context) : 
+      path.join(process.cwd(), 'template.yml');
+
     return include({
       template: yaml.load(template),
-      url: 'file://' + path.join(process.cwd(), 'template.yml'),
+      url: 'file://' + location,
     }).catch(err => console.error(err));
   });
 }


### PR DESCRIPTION
Runnable Example
`cat examples/base.template  | ./bin/cli.js --context examples/base.template`

Imagine you needed preprocessing done on the template

```sh
cat examples/base.template | sed s/toFind/toReplace/g | ./bin/cli.js --context examples/base.template
```

Without --context his would not work right now.